### PR TITLE
Update platform to 23.08

### DIFF
--- a/net.cebix.basilisk.yml
+++ b/net.cebix.basilisk.yml
@@ -1,6 +1,6 @@
 app-id: net.cebix.basilisk
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: BasiliskII
 finish-args:


### PR DESCRIPTION
The 21.08 platform has been marked EOL. I don't have a new release ready, can I simply bump the platform and rebuild?