### PR TITLE
Update the runtime version from 23.08 to 25.08, and more

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,37 @@
+From 47307927ac29a59b8ad12da7df3439d04f6cd3d8 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Wed, 10 Jun 2026 16:41:46 +0300
+Subject: [PATCH] Fix appdata paper cuts
+
+Signed-off-by: Sabri Ünal <yakushabb@gmail.com>
+---
+ BasiliskII/src/Unix/flatpak/net.cebix.basilisk.metainfo.xml | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/BasiliskII/src/Unix/flatpak/net.cebix.basilisk.metainfo.xml b/BasiliskII/src/Unix/flatpak/net.cebix.basilisk.metainfo.xml
+index b880821..1727681 100644
+--- a/BasiliskII/src/Unix/flatpak/net.cebix.basilisk.metainfo.xml
++++ b/BasiliskII/src/Unix/flatpak/net.cebix.basilisk.metainfo.xml
+@@ -15,13 +15,18 @@ Basilisk II is an Open Source 68k Macintosh emulator. That is, it enables you to
+ 
+   <url type="homepage">https://basilisk.cebix.net/</url>
+   <url type="bugtracker">https://github.com/SegHaxx/macemu-flatpak/issues</url>
++  <url type="vcs-browser">https://github.com/SegHaxx/macemu-flatpak</url>
++  <developer id="net.cebix">
++    <name>Christian Bauer</name>
++  </developer>
+ 
+   <launchable type="desktop-id">net.cebix.basilisk.desktop</launchable>
+ 
+   <screenshots>
+     <screenshot type="default">
+       <image>https://raw.githubusercontent.com/flathub/net.cebix.basilisk/master/screenshots/1.png</image>
+-    </screenshot><screenshot>
++    </screenshot>
++    <screenshot>
+       <image>https://raw.githubusercontent.com/flathub/net.cebix.basilisk/master/screenshots/2.png</image>
+     </screenshot>
+   </screenshots>
+--
+libgit2 1.7.2
+

--- a/net.cebix.basilisk.yml
+++ b/net.cebix.basilisk.yml
@@ -28,6 +28,8 @@ modules:
       - BasiliskII/COPYING
     sources:
       - type: git
+        url: https://github.com/SegHaxx/macemu-flatpak.git
         #branch: flatpak
         commit: f3295d824e863d2244b18f913586ea15880d571a
-        url: https://github.com/SegHaxx/macemu-flatpak.git
+      - type: patch
+        path: fix-appdata.patch

--- a/net.cebix.basilisk.yml
+++ b/net.cebix.basilisk.yml
@@ -24,6 +24,8 @@ modules:
     config-opts:
       # VOSF crashes on Ubuntu
       - --disable-vosf
+    license-files:
+      - BasiliskII/COPYING
     sources:
       - type: git
         #branch: flatpak

--- a/net.cebix.basilisk.yml
+++ b/net.cebix.basilisk.yml
@@ -1,6 +1,6 @@
 app-id: net.cebix.basilisk
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: BasiliskII
 finish-args:
@@ -14,15 +14,8 @@ finish-args:
 modules:
   - shared-modules/gtk2/gtk2.json
 
-  # required for FPU implementation on ARM
-  - name: mpfr
-    only-arches: [arm,aarch64]
-    config-opts:
-      - --disable-static
-    sources:
-      - type: archive
-        url: https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz
-        sha256: 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
+  # MPRF required for FPU implementation on ARM
+  # Used from the runtime
 
   - name: BasiliskII
     buildsystem: autotools


### PR DESCRIPTION
- Update the runtime version to 25.08
- Use the mpfr module from the runtime
- Update shared-modules
- Fix missing license file
- Fix appdata paper cuts